### PR TITLE
Build and Push docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,11 @@
-Dockerfile
-run-solid-test-suite.sh
+# Directories to ignore
 .git
+
+# Files to ignore
+.gitignore
+_config.yml
+CHANGELOG.md
+CODE_OF_CONDUCT.md
+CONTRIBUTING.md
+Dockerfile
+Gemfile

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,26 @@
+name: Build Docker Image
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  docker-build-pub-sub:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build Pub-Sub Docker image
+        run: |
+          docker build -t "ghcr.io/pdsinterop/php-solid-pubsub-server:latest" .
+          docker push "ghcr.io/pdsinterop/php-solid-pubsub-server:latest"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,18 @@
 FROM php:7.2
-RUN apt-get update && \
-    apt-get install -y \
+
+RUN apt-get update \
+    && apt-get install -yq --no-install-recommends \
         git \
-        zlib1g-dev 
-WORKDIR /tls
-WORKDIR /install
-RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-RUN php composer-setup.php
-RUN php -r "unlink('composer-setup.php');"
-ADD . /app
+        zip \
+        zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY . /app
+
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
+RUN composer install --working-dir=/app --no-dev --prefer-dist \
+    && rm  /usr/local/bin/composer
+
 WORKDIR /app
-RUN php /install/composer.phar install --no-dev --prefer-dist
 EXPOSE 8080
-CMD php server/server.php
+CMD ["php", "server/server.php"]


### PR DESCRIPTION
Rather than having the Solid-Nextcloud (and PHP Standalone) repos build their own Pub-Sup Server Docker image, it would make sense to have such an image already built.

This MR does that, as well as adding some minor cleanup to Docker related files.